### PR TITLE
Connection lost fix: Ethernet has an ability to restart itself

### DIFF
--- a/main/include/EthernetW5500.h
+++ b/main/include/EthernetW5500.h
@@ -24,13 +24,13 @@ public:
     esp_netif_t* pNetworkInterface_ = nullptr;
     void* pEthGlue_ = nullptr;
     void PrintShit();
+    void configureW5500Driver();
     void reconfigureDriver();
 
 private:
     void createNetworkInterface();
     void registerTcpHandlers() const;
     void configureSpiBus();
-    void configureW5500Driver();
     void installSpiEthernet();
     void startEthernet();
 

--- a/main/include/EthernetW5500.h
+++ b/main/include/EthernetW5500.h
@@ -23,6 +23,8 @@ public:
     esp_eth_handle_t ethHandle_{};
     esp_netif_t* pNetworkInterface_ = nullptr;
     void* pEthGlue_ = nullptr;
+    void PrintShit();
+    void reconfigureDriver();
 
 private:
     void createNetworkInterface();

--- a/main/include/EthernetW5500.h
+++ b/main/include/EthernetW5500.h
@@ -25,7 +25,6 @@ public:
     void* pEthGlue_ = nullptr;
     void executeEthernetStatusGuard();
     void configureW5500Driver();
-    void reconfigureDriver();
 
 private:
     void createNetworkInterface();
@@ -34,7 +33,7 @@ private:
     void installSpiEthernet();
     void startEthernet();
 
-    void waitForIP();
+    void waitForIP() const;
     bool isEthernetSanitized();
     static bool isOurNetIf(const std::string& str1, esp_netif_t* pTempNetInterface);
     static std::string createMacString(std::array<uint8_t, 6> mac);

--- a/main/include/EthernetW5500.h
+++ b/main/include/EthernetW5500.h
@@ -23,7 +23,7 @@ public:
     esp_eth_handle_t ethHandle_{};
     esp_netif_t* pNetworkInterface_ = nullptr;
     void* pEthGlue_ = nullptr;
-    void PrintShit();
+    void executeEthernetStatusGuard();
     void configureW5500Driver();
     void reconfigureDriver();
 
@@ -34,9 +34,10 @@ private:
     void installSpiEthernet();
     void startEthernet();
 
-    static void waitForIP();
-
+    void waitForIP();
+    bool isEthernetSanitized();
     static bool isOurNetIf(const std::string& str1, esp_netif_t* pTempNetInterface);
+    static std::string createMacString(std::array<uint8_t, 6> mac);
     spi_host_device_t spiInterface_ = SPI1_HOST;
     spi_bus_config_t spiBusCfg_ {};
     spi_device_interface_config_t spiDeviceCfg_{};

--- a/main/include/ModbusDefinitions.h
+++ b/main/include/ModbusDefinitions.h
@@ -22,6 +22,7 @@
 
 #define MODBUS_TCP_PORT 502
 #define MODBUS_PARAM_TIMEOUT 10
+#define SECOND 100
 const std::string EthTag = "ETH Connection module";
 const std::string ModbusTag = "Modbus Slave module";
 static portMUX_TYPE modbusMutex = portMUX_INITIALIZER_UNLOCKED;

--- a/main/src/EthernetW5500.cpp
+++ b/main/src/EthernetW5500.cpp
@@ -130,17 +130,47 @@ bool EthernetW5500::isOurNetIf(const std::string& str1,
     std::string str2 = esp_netif_get_desc(pTempNetInterface);
     return str1 == str2.substr(0, str1.length());
 }
+
 void EthernetW5500::PrintShit() {
     esp_netif_t* pTempNetInterface = nullptr;
     esp_netif_ip_info_t ip;
+    uint8_t mac[6];
     for (int i = 0; i < esp_netif_get_nr_of_ifs(); ++i) {
         pTempNetInterface = esp_netif_next(pTempNetInterface);
         if (isOurNetIf(EthTag, pTempNetInterface)) {
             ESP_ERROR_CHECK(esp_netif_get_ip_info(pTempNetInterface, &ip));
-
+            esp_netif_get_mac(pTempNetInterface, mac);
             ESP_LOGW(EthTag.c_str(), "- IPv4 address: " IPSTR, IP2STR(&ip.ip));
+            std::array<uint8_t, 6> data{};
+            uint32_t phy_read;
+//            pMac_->get_addr(pMac_, data.data());
+//#define W5500_BSB_COM_REG        (0x00)    // Common Register
+//#define W5500_ADDR_OFFSET (16) // Address length
+//#define W5500_BSB_OFFSET  (3)  // Block Select Bits offset
+//#define W5500_MAKE_MAP(offset, bsb) ((offset) << W5500_ADDR_OFFSET | (bsb) << W5500_BSB_OFFSET)
+//#define W5500_REG_PHYCFGR   W5500_MAKE_MAP(0x002E, W5500_BSB_COM_REG) // PHY Configuration
+//            pMac_->read_phy_reg(pMac_, 1,W5500_REG_PHYCFGR,&phy_read);
+//            ESP_LOGW(EthTag.c_str(), "MAC: %d:%d:%d:%d:%d:%d", data[0],data[1],data[2],data[3],data[4],data[5]);
+//            ESP_LOGW(EthTag.c_str(), "- PHY read %d", phy_read);
+
+//            uint32_t phy_add=88;
+//            pPhy_->get_addr(pPhy_, &phy_add);
+//            ESP_LOGW(EthTag.c_str(), "- PHY %d", phy_add);
             if (ip.ip.addr == 0){
                 ESP_LOGW(EthTag.c_str(), "***DANGER NO IP DANGER***");
+                std::array<uint8_t, 6> macaddr{};
+                uint32_t phy;
+                eth_speed_t speed;
+                eth_duplex_t duplex;
+                esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, macaddr.data());
+                esp_eth_ioctl(ethHandle_, ETH_CMD_G_PHY_ADDR, &phy);
+                esp_eth_ioctl(ethHandle_, ETH_CMD_G_DUPLEX_MODE, &duplex);
+                esp_eth_ioctl(ethHandle_, ETH_CMD_G_SPEED, &speed);
+                ESP_LOGW(EthTag.c_str(), "MAC ADDR: %x:%x:%x:%x:%x:%x", macaddr[0],macaddr[1],macaddr[2],macaddr[3],macaddr[4],macaddr[5]);
+                ESP_LOGW(EthTag.c_str(), "PHY:      %d", phy);
+                ESP_LOGW(EthTag.c_str(), "Duplex:   %d", duplex);
+                ESP_LOGW(EthTag.c_str(), "Speed:    %d", speed);
+
                 ethernetStopHandler();
                 esp_unregister_shutdown_handler(&ethernetStopHandler);
 //                esp_netif_deinit();
@@ -189,5 +219,22 @@ void EthernetW5500::PrintShit() {
     }
 }
 void EthernetW5500::reconfigureDriver() {
-    configureW5500Driver();
+    std::array<uint8_t, 6> macaddr{};
+    uint32_t phy;
+    eth_speed_t speed;
+    eth_duplex_t duplex;
+    esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, macaddr.data());
+    esp_eth_ioctl(ethHandle_, ETH_CMD_G_PHY_ADDR, &phy);
+    esp_eth_ioctl(ethHandle_, ETH_CMD_G_DUPLEX_MODE, &duplex);
+    esp_eth_ioctl(ethHandle_, ETH_CMD_G_SPEED, &speed);
+    ESP_LOGW(EthTag.c_str(), "Normal work: MAC ADDR: %x:%x:%x:%x:%x:%x", macaddr[0],macaddr[1],macaddr[2],macaddr[3],macaddr[4],macaddr[5]);
+    ESP_LOGW(EthTag.c_str(), "Normal work: PHY:      %d", phy);
+    ESP_LOGW(EthTag.c_str(), "Normal work: Duplex:   %d", duplex);
+    ESP_LOGW(EthTag.c_str(), "Normal work: Speed:    %d", speed);
+//    configureW5500Driver();
+//    esp_eth_ioctl(ethHandle_, ETH_CMD_S_MAC_ADDR, macAddr_.data());
+//    std::array<uint8_t, 6> mac{};
+//    esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, mac.data());
+//    ESP_LOGW(EthTag.c_str(), "SANDFKSJDNFKJSNDFKJSD: %d:%d:%d:%d:%d:%d", mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+    // todo: esp_eth_ioctl lekiem na cale zlo???
 }

--- a/main/src/EthernetW5500.cpp
+++ b/main/src/EthernetW5500.cpp
@@ -4,6 +4,8 @@
 
 #include "EthernetW5500.h"
 #include <tuple>
+#include <sstream>
+#include <iomanip>
 
 #include "esp_event.h"
 #include "esp_log.h"
@@ -101,29 +103,16 @@ void EthernetW5500::startEthernet() {
 
 void EthernetW5500::waitForIP() {
     sem_ip = xSemaphoreCreateCounting(1, 0);
+    esp_netif_ip_info_t ip;
     ESP_ERROR_CHECK(esp_register_shutdown_handler(&ethernetStopHandler));
     ESP_LOGI(EthTag.c_str(), "Waiting for IP(s)");
-    ESP_LOGI(EthTag.c_str(), "Sem waiting");
-    xSemaphoreTake(sem_ip, portMAX_DELAY);
-    ESP_LOGI(EthTag.c_str(), "After sem take");
-    // iterate over active interfaces, and print out IPs of "our" netifs
-    esp_netif_t* pTempNetInterface = nullptr;
-    esp_netif_ip_info_t ip;
-    // esp_netif_get_handle_from_ifkey!!!!
-    for (int i = 0; i < esp_netif_get_nr_of_ifs(); ++i) {
-        ESP_LOGI(EthTag.c_str(), "Some shitty ESP netif FOR");
-        pTempNetInterface = esp_netif_next(pTempNetInterface);
-        if (isOurNetIf(EthTag, pTempNetInterface)) {
-            ESP_LOGI(EthTag.c_str(),
-                     "Connected to %s",
-                     esp_netif_get_desc(pTempNetInterface));
-            ESP_ERROR_CHECK(esp_netif_get_ip_info(pTempNetInterface, &ip));
-
-            ESP_LOGI(EthTag.c_str(), "- IPv4 address: " IPSTR, IP2STR(&ip.ip));
-        }
-    }
-//    ESP_LOGI(EthTag.c_str(), "No connection sadge");
+    xSemaphoreTake(sem_ip, SECOND * 15);
+    ESP_LOGI(EthTag.c_str(), "Connected to %s",
+             esp_netif_get_desc(pNetworkInterface_));
+    ESP_ERROR_CHECK(esp_netif_get_ip_info(pNetworkInterface_, &ip));
+    ESP_LOGI(EthTag.c_str(), "- IPv4 address: " IPSTR, IP2STR(&ip.ip));
 }
+
 
 bool EthernetW5500::isOurNetIf(const std::string& str1,
                                esp_netif_t* pTempNetInterface) {
@@ -131,92 +120,62 @@ bool EthernetW5500::isOurNetIf(const std::string& str1,
     return str1 == str2.substr(0, str1.length());
 }
 
-void EthernetW5500::PrintShit() {
-    esp_netif_t* pTempNetInterface = nullptr;
+void EthernetW5500::executeEthernetStatusGuard() {
     esp_netif_ip_info_t ip;
-    uint8_t mac[6];
-    for (int i = 0; i < esp_netif_get_nr_of_ifs(); ++i) {
-        pTempNetInterface = esp_netif_next(pTempNetInterface);
-        if (isOurNetIf(EthTag, pTempNetInterface)) {
-            ESP_ERROR_CHECK(esp_netif_get_ip_info(pTempNetInterface, &ip));
-            esp_netif_get_mac(pTempNetInterface, mac);
-            ESP_LOGW(EthTag.c_str(), "- IPv4 address: " IPSTR, IP2STR(&ip.ip));
-            std::array<uint8_t, 6> data{};
-            uint32_t phy_read;
-//            pMac_->get_addr(pMac_, data.data());
-//#define W5500_BSB_COM_REG        (0x00)    // Common Register
-//#define W5500_ADDR_OFFSET (16) // Address length
-//#define W5500_BSB_OFFSET  (3)  // Block Select Bits offset
-//#define W5500_MAKE_MAP(offset, bsb) ((offset) << W5500_ADDR_OFFSET | (bsb) << W5500_BSB_OFFSET)
-//#define W5500_REG_PHYCFGR   W5500_MAKE_MAP(0x002E, W5500_BSB_COM_REG) // PHY Configuration
-//            pMac_->read_phy_reg(pMac_, 1,W5500_REG_PHYCFGR,&phy_read);
-//            ESP_LOGW(EthTag.c_str(), "MAC: %d:%d:%d:%d:%d:%d", data[0],data[1],data[2],data[3],data[4],data[5]);
-//            ESP_LOGW(EthTag.c_str(), "- PHY read %d", phy_read);
+    std::array<uint8_t, 6> macaddr{};
+    uint32_t phy;
 
-//            uint32_t phy_add=88;
-//            pPhy_->get_addr(pPhy_, &phy_add);
-//            ESP_LOGW(EthTag.c_str(), "- PHY %d", phy_add);
-            if (ip.ip.addr == 0){
-                ESP_LOGW(EthTag.c_str(), "***DANGER NO IP DANGER***");
-                std::array<uint8_t, 6> macaddr{};
-                uint32_t phy;
-                eth_speed_t speed;
-                eth_duplex_t duplex;
-                esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, macaddr.data());
-                esp_eth_ioctl(ethHandle_, ETH_CMD_G_PHY_ADDR, &phy);
-                esp_eth_ioctl(ethHandle_, ETH_CMD_G_DUPLEX_MODE, &duplex);
-                esp_eth_ioctl(ethHandle_, ETH_CMD_G_SPEED, &speed);
-                ESP_LOGW(EthTag.c_str(), "MAC ADDR: %x:%x:%x:%x:%x:%x", macaddr[0],macaddr[1],macaddr[2],macaddr[3],macaddr[4],macaddr[5]);
-                ESP_LOGW(EthTag.c_str(), "PHY:      %d", phy);
-                ESP_LOGW(EthTag.c_str(), "Duplex:   %d", duplex);
-                ESP_LOGW(EthTag.c_str(), "Speed:    %d", speed);
+    ESP_ERROR_CHECK(esp_netif_get_ip_info(pNetworkInterface_, &ip));
+    ESP_ERROR_CHECK(
+        esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, macaddr.data()));
+    ESP_ERROR_CHECK(esp_eth_ioctl(ethHandle_, ETH_CMD_G_PHY_ADDR, &phy));
+    std::string macStr = createMacString(macaddr);
+    ESP_LOGI(EthTag.c_str(), "IPv4 found: " IPSTR, IP2STR(&ip.ip));
+    ESP_LOGI(EthTag.c_str(), "MAC found: %s", macStr.c_str());
+    ESP_LOGI(EthTag.c_str(), "PHY found: %d", phy);
 
-                ethernetStopHandler();
-                esp_unregister_shutdown_handler(&ethernetStopHandler);
-//                esp_netif_deinit();
-//                esp_eth_stop(ethHandle_);
-//                esp_netif_destroy(pNetworkInterface_);
-//                pNetworkInterface_ = nullptr;
-                esp_netif_init();
-                esp_netif_inherent_config_t
-                    netIfBaseCfg = ESP_NETIF_INHERENT_DEFAULT_ETH(); // todo: replace with
-                // some custom
-                std::string netIfTag = EthTag + ": " +
-                                       static_cast<std::string>(netIfBaseCfg.if_desc);
-                netIfBaseCfg.if_desc = netIfTag.c_str();
-                netIfBaseCfg.route_prio = 64;
-                esp_netif_config_t netIfCfg = {.base = &netIfBaseCfg,
-                    .driver = nullptr,
-                    .stack = ESP_NETIF_NETSTACK_DEFAULT_ETH};
-
-                pNetworkInterface_ = esp_netif_new(&netIfCfg);
-                assert(pNetworkInterface_);
-                registerTcpHandlers();
-//                spi_bus_add_device(spiInterface_, &spiDeviceCfg_, &pSpiHandle_);
-                configureW5500Driver();
-                installSpiEthernet();
-                startEthernet();
-
-                sem_ip = xSemaphoreCreateCounting(1, 0);
-                ESP_ERROR_CHECK(esp_register_shutdown_handler(&ethernetStopHandler));
-                ESP_LOGI(EthTag.c_str(), "Waiting for IP(s)");
-                ESP_LOGI(EthTag.c_str(), "Sem waiting");
-                xSemaphoreTake(sem_ip, portMAX_DELAY);
-                ESP_LOGI(EthTag.c_str(), "After sem take");
-                esp_netif_t* pTempNetInterfaceNEW = nullptr;
-                esp_netif_ip_info_t ipNEW;
-                for (int i = 0; i < esp_netif_get_nr_of_ifs(); ++i) {
-                    pTempNetInterfaceNEW = esp_netif_next(pTempNetInterfaceNEW);
-                    if (isOurNetIf(EthTag, pTempNetInterfaceNEW)) {
-                        ESP_ERROR_CHECK(esp_netif_get_ip_info(pTempNetInterfaceNEW, &ipNEW));
-
-                        ESP_LOGW(EthTag.c_str(), "- IPv4 address: " IPSTR, IP2STR(&ipNEW.ip));
-                    }
-                }
-
+    if (ip.ip.addr == 0 || macaddr != macAddr_ || phy != 1) {
+        ESP_LOGE(EthTag.c_str(),
+                 "IP / MAC / PHY Missing. Performing Ethernet reset up to 10 times");
+        for (std::size_t i=0; i<3; i++){
+            if (isEthernetSanitized()){
+                break;
+            }
+            if (i==2){
+                ESP_LOGE(EthTag.c_str(),
+                         "Getting IP not possible. Performing SW reset.");
+                vTaskDelay(SECOND*2);
+                esp_restart();
             }
         }
     }
+}
+
+bool EthernetW5500::isEthernetSanitized() {
+    bool isEthernet = false;
+    ethernetStopHandler();
+    esp_unregister_shutdown_handler(&ethernetStopHandler);
+    spi_bus_remove_device(pSpiHandle_);
+    spi_bus_free(spiInterface_);
+
+    createNetworkInterface();
+    ConfigureAndStart();
+    esp_netif_ip_info_t ip;
+    esp_netif_get_ip_info(pNetworkInterface_, &ip);
+    if (ip.ip.addr){
+        isEthernet = true;
+    }
+    return isEthernet;
+}
+std::string EthernetW5500::createMacString(std::array<uint8_t, 6> mac) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (auto& val : mac) {
+        oss << std::setw(2) << (unsigned int) val << ":";
+    }
+    std::string retMac = oss.str();
+    retMac.pop_back();
+    return retMac;
 }
 void EthernetW5500::reconfigureDriver() {
     std::array<uint8_t, 6> macaddr{};
@@ -227,14 +186,22 @@ void EthernetW5500::reconfigureDriver() {
     esp_eth_ioctl(ethHandle_, ETH_CMD_G_PHY_ADDR, &phy);
     esp_eth_ioctl(ethHandle_, ETH_CMD_G_DUPLEX_MODE, &duplex);
     esp_eth_ioctl(ethHandle_, ETH_CMD_G_SPEED, &speed);
-    ESP_LOGW(EthTag.c_str(), "Normal work: MAC ADDR: %x:%x:%x:%x:%x:%x", macaddr[0],macaddr[1],macaddr[2],macaddr[3],macaddr[4],macaddr[5]);
+    ESP_LOGW(EthTag.c_str(),
+             "Normal work: MAC ADDR: %x:%x:%x:%x:%x:%x",
+             macaddr[0],
+             macaddr[1],
+             macaddr[2],
+             macaddr[3],
+             macaddr[4],
+             macaddr[5]);
     ESP_LOGW(EthTag.c_str(), "Normal work: PHY:      %d", phy);
     ESP_LOGW(EthTag.c_str(), "Normal work: Duplex:   %d", duplex);
     ESP_LOGW(EthTag.c_str(), "Normal work: Speed:    %d", speed);
-//    configureW5500Driver();
-//    esp_eth_ioctl(ethHandle_, ETH_CMD_S_MAC_ADDR, macAddr_.data());
-//    std::array<uint8_t, 6> mac{};
-//    esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, mac.data());
-//    ESP_LOGW(EthTag.c_str(), "SANDFKSJDNFKJSNDFKJSD: %d:%d:%d:%d:%d:%d", mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+    //    configureW5500Driver();
+    //    esp_eth_ioctl(ethHandle_, ETH_CMD_S_MAC_ADDR, macAddr_.data());
+    //    std::array<uint8_t, 6> mac{};
+    //    esp_eth_ioctl(ethHandle_, ETH_CMD_G_MAC_ADDR, mac.data());
+    //    ESP_LOGW(EthTag.c_str(), "SANDFKSJDNFKJSNDFKJSD: %d:%d:%d:%d:%d:%d",
+    //    mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
     // todo: esp_eth_ioctl lekiem na cale zlo???
 }

--- a/main/src/Free.cpp
+++ b/main/src/Free.cpp
@@ -23,15 +23,6 @@ static void onGotIpHandler(void* arg,
 }
 
 static void ethernetStopHandler() {
-    esp_netif_t* tmp_netif = nullptr;
-    std::string netif_description = EthTag + ": eth";
-    while ((tmp_netif = esp_netif_next(tmp_netif)) != nullptr) {
-        std::string str2 = esp_netif_get_desc(tmp_netif);
-        if (netif_description == str2.substr(0, netif_description.length())) {
-            break;
-        }
-    }
-    esp_netif_t* eth_netif = tmp_netif;
     ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT,
                                                  IP_EVENT_ETH_GOT_IP,
                                                  &onGotIpHandler));
@@ -39,9 +30,7 @@ static void ethernetStopHandler() {
     auto& ethInstance = EthernetW5500::getInstance();
     ESP_ERROR_CHECK(esp_eth_stop(ethInstance.ethHandle_));
     ESP_ERROR_CHECK(esp_eth_del_netif_glue(ethInstance.pEthGlue_));
-    ESP_ERROR_CHECK(esp_eth_clear_default_handlers(eth_netif));
+    ESP_ERROR_CHECK(esp_eth_clear_default_handlers(ethInstance.pNetworkInterface_));
     ESP_ERROR_CHECK(esp_eth_driver_uninstall(ethInstance.ethHandle_));
-
-    esp_netif_destroy(eth_netif);
-    ethInstance.pNetworkInterface_ = nullptr;
+    esp_netif_destroy(ethInstance.pNetworkInterface_);
 }


### PR DESCRIPTION
Ethernet is now able to restart connection if one is lost. Restarting may appear during:
* cable breaks
* Ethernet power loss
* resetting W5500 module
After 3 unsuccessful attempts esp will get restarted.